### PR TITLE
Fixing type error on Null return for 2 methods

### DIFF
--- a/src/services/EventbriteEvents.php
+++ b/src/services/EventbriteEvents.php
@@ -228,13 +228,13 @@ class EventbriteEvents extends Component
    *
    *     Eventbrite::$plugin->eventbriteService->exampleService()
    *
-   * @return mixed
+   * @return array
    */
   public function getVenue($venueId) : array
   {
     $method = "/v3/venues/" . $venueId . "/";
     
-    $venue = $this->curlWrap($method);
+    $venue = $this->curlWrap($method) ?: [];
     
     return $venue;
   }

--- a/src/services/EventbriteEvents.php
+++ b/src/services/EventbriteEvents.php
@@ -164,13 +164,13 @@ class EventbriteEvents extends Component
    *
    *     Eventbrite::$plugin->eventbriteService->exampleService()
    *
-   * @return mixed
+   * @return array
    */
   private function getEventDescription($eventId) : array
   {
     $method = "/v3/events/" . $eventId . "/description/";
     
-    $eventDescription = $this->curlWrap($method);
+    $eventDescription = $this->curlWrap($method) ?: [];
     
     return $eventDescription;
   }


### PR DESCRIPTION
getVenue 
getEventDescription

Both updated to return an array if null - fixing type error. 